### PR TITLE
Tomas dev

### DIFF
--- a/flp/urls.py
+++ b/flp/urls.py
@@ -35,9 +35,9 @@ urlpatterns = [
     path('checkout/', views.checkout_action, name='Checkout'),
     path('createitem/<str:location>/', views.createItem_action, name='CreateItem'),
     path('createFamily/<str:location>/', views.createFamily_action, name='CreateFamily'),
+    path('editquantity/<int:index>/<str:location>/<int:qty>/', views.editquantity_action, name='EditQuantity'),
+    path('editisnew/<int:index>/<str:location>/<int:isnew>/', views.editisnew_action, name='EditIsNew'),
     path('removeitem/<int:index>/<str:location>/', views.removeitem_action, name='RemoveItem'),
-    path('plusquantity/<int:index>/<str:location>/', views.plusquantity_action, name='PlusQuantity'),
-    path('minusquantity/<int:index>/<str:location>/', views.minusquantity_action, name='MinusQuantity'),
     path('analytics/analytics/', views.analytics, name='Analytics'),
 
     path('families/index/', views.FamilyIndexView.as_view(), name="Families"),

--- a/flp/urls.py
+++ b/flp/urls.py
@@ -36,6 +36,8 @@ urlpatterns = [
     path('createitem/<str:location>/', views.createItem_action, name='CreateItem'),
     path('createFamily/<str:location>/', views.createFamily_action, name='CreateFamily'),
     path('removeitem/<int:index>/<str:location>/', views.removeitem_action, name='RemoveItem'),
+    path('plusquantity/<int:index>/<str:location>/', views.plusquantity_action, name='PlusQuantity'),
+    path('minusquantity/<int:index>/<str:location>/', views.minusquantity_action, name='MinusQuantity'),
     path('analytics/analytics/', views.analytics, name='Analytics'),
 
     path('families/index/', views.FamilyIndexView.as_view(), name="Families"),

--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -117,7 +117,7 @@ class AddItemForm(forms.Form):
     item = forms.CharField(max_length=50,
                            widget=forms.TextInput(attrs={'class': 'form-control'}))
     quantity = forms.IntegerField(widget=forms.TextInput(attrs={'class': 'form-control'}))
-    is_new = forms.BooleanField(required=False, widget=forms.CheckboxInput(attrs={'class': 'form-checkbox'}), label="New")
+    is_new = forms.BooleanField(required=False, widget=forms.CheckboxInput(attrs={'class': 'form-checkbox'}), label="New2")
     required_css_class = 'required'
 
     # Customizes form validation for properties that apply to more
@@ -156,7 +156,7 @@ class AddItemForm(forms.Form):
     def clean_is_new(self):
         is_new = self.cleaned_data.get('is_new')
         return is_new
-
+    
 class CheckOutForm(forms.Form):
     family = forms.CharField(max_length=50,
                            widget=forms.TextInput(attrs={'class': 'form-control'}))
@@ -165,6 +165,7 @@ class CheckOutForm(forms.Form):
                            widget=forms.TextInput(attrs={'class': 'form-control'}), required=False)
     age   = forms.ModelChoiceField(queryset=AgeRange.objects.all(),
                                         widget=forms.Select(attrs={'class': 'form-select'}))
+    
 
     # Customizes form validation for properties that apply to more
     # than one field.  Overrides the forms.Form.clean function.

--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -117,7 +117,7 @@ class AddItemForm(forms.Form):
     item = forms.CharField(max_length=50,
                            widget=forms.TextInput(attrs={'class': 'form-control'}))
     quantity = forms.IntegerField(widget=forms.TextInput(attrs={'class': 'form-control'}))
-    is_new = forms.BooleanField(required=False, widget=forms.CheckboxInput(attrs={'class': 'form-checkbox'}), label="New2")
+    is_new = forms.BooleanField(required=False, widget=forms.CheckboxInput(attrs={'class': 'form-checkbox'}), label="New")
     required_css_class = 'required'
 
     # Customizes form validation for properties that apply to more

--- a/inventory/static/inventory/checkout_scripts.js
+++ b/inventory/static/inventory/checkout_scripts.js
@@ -51,4 +51,21 @@ $(document).ready(function() {
     localStorage.removeItem(LOCAL_STORAGE_NOTES)
     localStorage.setItem('old-notes-field', oldNotes) // in case a Checkout validation fails 
   })
+
+  $('#qtyDropdownMenu').on('click', function(){
+    var textBox = document.getElementById('qtyText')
+    var updateBtn = document.getElementById('updateBtn')
+
+    if($(this).text() == "10+") {
+      textBox.style.display='block'
+      updateBtn.style.display='inline-block'
+    }
+    else {
+      textBox.style.display='none'
+      updateBtn.style.display='none'
+    }
+
+  })
+
 });
+

--- a/inventory/templates/inventory/checkin.html
+++ b/inventory/templates/inventory/checkin.html
@@ -51,11 +51,44 @@
           {% for tx in transactions %}
             <tr> 
                 <th scope="row">{{ tx.item }}</th>
-                <td>{{ tx.quantity }}</td>
-                <td>{% if tx.is_new %} New {% else %} Used {% endif %}</td>
                 <td>
-                  <a href="{% url 'RemoveItem' index=forloop.counter0 location='in' %}" class="btn-sm btn-danger save-notes-on-click">
+                  <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" id="qtyDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                    {{ tx.quantity }}
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="qty-menu" id="qtyDropdownMenu">
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=1%}">1</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=2%}">2</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=3%}">3</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=4%}">4</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=5%}">5</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=6%}">6</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=7%}">7</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=8%}">8</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=9%}">9</a>
+                    <a class="dropdown-item" href="#" >10+</a>
+                    </div>
+                  </div>
+                  <input type="text" name="qtyText" id="qtyText" style='display:none'/>
+                </td>
+                <td>
+                  <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" id="newDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                      {% if tx.is_new %} New {% else %} Used {% endif %}
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="new-menu" id="newDropdownMenu">
+                    <a class="dropdown-item" href="{% url 'EditIsNew' index=forloop.counter0 location='in' isnew=1%}">New</a>
+                    <a class="dropdown-item" href="{% url 'EditIsNew' index=forloop.counter0 location='in' isnew=0%}">Used</a>
+                    </div>
+                </div>
+                </td>
+                <td>
+                  <a href="{% url 'RemoveItem' index=forloop.counter0 location='in' %}" class="btn btn-danger btn-sm save-notes-on-click">
                     Remove
+                  </a>
+                  <div class="divider"></div>
+                  <a id="updateBtn" href="{% url 'EditQuantity' index=forloop.counter0 location='in' qty=10%}" class="btn btn-warning btn-sm save-notes-on-click" style='display:none'>
+                    Update
                   </a>
                 </td>
             </tr>

--- a/inventory/templates/inventory/checkout.html
+++ b/inventory/templates/inventory/checkout.html
@@ -13,6 +13,12 @@
       justify-content: space-between;
     }
 
+    .divider{
+      width: 10px;
+      height:auto;
+      display:inline-block;
+    }
+
     .checkout-form {
       display: flex;
       align-items: flex-start;
@@ -64,7 +70,6 @@
           <tr>
               <th scope="col">Name</th>
               <th scope="col">Quantity</th>
-              <th scope="col">Edit</th>
               <th scope="col">New/Used</th>
               <th scope="col">Actions</th>
           </tr>
@@ -73,19 +78,44 @@
           {% for tx in transactions %}
             <tr> 
                 <th scope="row">{{ tx.item}}</th>
-                <td>{{ tx.quantity }}</td>
                 <td>
-                  <a href="{% url 'PlusQuantity' index=forloop.counter0 location='out' %}" class="btn-sm btn-success save-notes-on-click">
-                    +
-                  </a>
-                  <a href="{% url 'MinusQuantity' index=forloop.counter0 location='out' %}" class="btn-sm btn-danger save-notes-on-click">
-                    -
-                  </a>
+                  <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" id="qtyDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                    {{ tx.quantity }}
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="qty-menu" id="qtyDropdownMenu">
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=1%}">1</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=2%}">2</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=3%}">3</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=4%}">4</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=5%}">5</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=6%}">6</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=7%}">7</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=8%}">8</a>
+                    <a class="dropdown-item" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=9%}">9</a>
+                    <a class="dropdown-item" href="#" >10+</a>
+                    </div>
+                  </div>
+                  <input type="text" name="qtyText" id="qtyText" style='display:none'/>
                 </td>
-                <td>{% if tx.is_new %} New {% else %} Used {% endif %}</td>
                 <td>
-                  <a href="{% url 'RemoveItem' index=forloop.counter0 location='out' %}" class="btn-sm btn-danger save-notes-on-click">
+                  <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" id="newDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                      {% if tx.is_new %} New {% else %} Used {% endif %}
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="new-menu" id="newDropdownMenu">
+                    <a class="dropdown-item" href="{% url 'EditIsNew' index=forloop.counter0 location='out' isnew=1%}">New</a>
+                    <a class="dropdown-item" href="{% url 'EditIsNew' index=forloop.counter0 location='out' isnew=0%}">Used</a>
+                    </div>
+                </div>
+                </td>
+                <td>
+                  <a href="{% url 'RemoveItem' index=forloop.counter0 location='out' %}" class="btn btn-danger btn-sm save-notes-on-click">
                     Remove
+                  </a>
+                  <div class="divider"></div>
+                  <a id="updateBtn" href="{% url 'EditQuantity' index=forloop.counter0 location='out' qty=10%}" class="btn btn-warning btn-sm save-notes-on-click" style='display:none'>
+                    Update
                   </a>
                 </td>
             </tr>
@@ -171,7 +201,6 @@
   <script>
     $(document).ready(function(){
       // -------------- FAMILY SCRIPTS: --------------
-
       var createdFamily = $("#fromCreatedFamilyRedirect").first().attr('value')
 
       if (createdFamily != 'no family') { localStorage.setItem("family", createdFamily); }

--- a/inventory/templates/inventory/checkout.html
+++ b/inventory/templates/inventory/checkout.html
@@ -64,6 +64,7 @@
           <tr>
               <th scope="col">Name</th>
               <th scope="col">Quantity</th>
+              <th scope="col">Edit</th>
               <th scope="col">New/Used</th>
               <th scope="col">Actions</th>
           </tr>
@@ -73,6 +74,14 @@
             <tr> 
                 <th scope="row">{{ tx.item}}</th>
                 <td>{{ tx.quantity }}</td>
+                <td>
+                  <a href="{% url 'PlusQuantity' index=forloop.counter0 location='out' %}" class="btn-sm btn-success save-notes-on-click">
+                    +
+                  </a>
+                  <a href="{% url 'MinusQuantity' index=forloop.counter0 location='out' %}" class="btn-sm btn-danger save-notes-on-click">
+                    -
+                  </a>
+                </td>
                 <td>{% if tx.is_new %} New {% else %} Used {% endif %}</td>
                 <td>
                   <a href="{% url 'RemoveItem' index=forloop.counter0 location='out' %}" class="btn-sm btn-danger save-notes-on-click">

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -367,6 +367,28 @@ def removeitem_action(request, index, location):
 
     return redirect(reverse('Check' + location))
 
+def plusquantity_action(request, index, location):
+    saved_list = request.session['transactions-' + location]
+
+    curr_item = json.loads(saved_list[index])
+    curr_item[0]['fields']['quantity'] += 1
+    saved_list[index] = json.dumps(curr_item)
+    request.session['transactions-' + location] = saved_list
+
+    return redirect(reverse('Check' + location))
+
+def minusquantity_action(request, index, location):
+    saved_list = request.session['transactions-' + location]
+
+    curr_item = json.loads(saved_list[index])
+    if (curr_item[0]['fields']['quantity'] > 1):
+        curr_item[0]['fields']['quantity'] -= 1
+    saved_list[index] = json.dumps(curr_item)
+    request.session['transactions-' + location] = saved_list
+
+    return redirect(reverse('Check' + location))
+
+
 # Create Family View 
 @login_required
 def createFamily_action(request, location):

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,4 +1,5 @@
 
+from re import S
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.core import serializers
@@ -367,27 +368,29 @@ def removeitem_action(request, index, location):
 
     return redirect(reverse('Check' + location))
 
-def plusquantity_action(request, index, location):
-    saved_list = request.session['transactions-' + location]
 
+def editquantity_action(request, index, location, qty):
+    saved_list = request.session['transactions-' + location]
     curr_item = json.loads(saved_list[index])
-    curr_item[0]['fields']['quantity'] += 1
+    curr_item[0]['fields']['quantity'] = qty
+    
     saved_list[index] = json.dumps(curr_item)
     request.session['transactions-' + location] = saved_list
 
-    return redirect(reverse('Check' + location))
+    return redirect(reverse('Check' + location))  
 
-def minusquantity_action(request, index, location):
+def editisnew_action(request, index, location, isnew):
     saved_list = request.session['transactions-' + location]
-
     curr_item = json.loads(saved_list[index])
-    if (curr_item[0]['fields']['quantity'] > 1):
-        curr_item[0]['fields']['quantity'] -= 1
+    if (isnew == 1):
+        curr_item[0]['fields']['is_new'] = True
+    else:
+        curr_item[0]['fields']['is_new'] = False
+
     saved_list[index] = json.dumps(curr_item)
     request.session['transactions-' + location] = saved_list
 
-    return redirect(reverse('Check' + location))
-
+    return redirect(reverse('Check' + location))  
 
 # Create Family View 
 @login_required
@@ -599,7 +602,7 @@ def checkout_action(request):
 
         item = Item.objects.filter(name=name).first()
     
-        tx = serializers.serialize("json", [ ItemTransaction(item=item, quantity=quantity, is_new=is_new), ])
+        tx = serializers.serialize("json", [ ItemTransaction(item=item, quantity=quantity, is_new=is_new, ), ])
         if not 'transactions-out' in request.session or not request.session['transactions-out']:
             saved_list = []
         else:


### PR DESCRIPTION
PR Details:
 - Resolves #1 

 - Front-end: Quantity and Used/New Dropdowns have been added to the Check-In and Check-out pages for quick and simple 1-click editing.
 
 - Back-end: Values of Quantity and New/Used are updated accordingly to the values selected within the dropdowns
 
- Purpose: To simplify the editing process when an item has already been added to the check-in or check-out pages. Doing this, users no longer have to re-type in the same item to change the quantity or the used/new type of the item. This also solves any initial errors from the user taking up too much time as the editing simply requires one click. 

- What is Missing: The textbox addition when a user selects "10+" needs to be added using a jQuery on-click function to make the dropdown disappear and make the textbox and update buttons appear. 

- Visual(s):
![Screen Shot 2022-02-19 at 4 39 01 PM](https://user-images.githubusercontent.com/72578647/154820077-5a62d0dc-5a5e-4b96-8b1f-58f0c1a90d0a.png)
![Screen Shot 2022-02-19 at 4 39 25 PM](https://user-images.githubusercontent.com/72578647/154820081-18885932-78f3-4932-80cf-5e6c6aa9f805.png)
![Screen Shot 2022-02-19 at 4 39 54 PM](https://user-images.githubusercontent.com/72578647/154820096-61129198-c55c-427f-9cc6-b1415d7f2572.png)




