### PR TITLE
Updated deployment configuration to use docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-
+*
 !.flake8
 !Procfile
 !bandit.yaml
@@ -10,4 +10,3 @@
 !manage_items.xlsx
 !requirements.txt
 !runtime.txt
-*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,13 @@
-*
-!flp
-!inventory
+
 !.flake8
 !Procfile
 !bandit.yaml
 !email_backups.py
+!flp
+!inventory
+!manage.py
 !manage_inventory.xlsx
 !manage_items.xlsx
 !requirements.txt
 !runtime.txt
+*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*
+!flp
+!inventory
+!.flake8
+!Procfile
+!bandit.yaml
+!email_backups.py
+!manage_inventory.xlsx
+!manage_items.xlsx
+!requirements.txt
+!runtime.txt

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !Procfile
 !bandit.yaml
 !deploy/env
+!docker/serve.sh
 !email_backups.py
 !flp
 !inventory

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !.flake8
 !Procfile
 !bandit.yaml
+!deploy/env
 !email_backups.py
 !flp
 !inventory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
 FROM python:3.6-alpine
-
-EXPOSE 80
-
-RUN apk add --no-cache gcc python3-dev musl-dev
+USER django
+RUN apk add --no-cache \
+  gcc \
+  musl-dev
+  python3-dev \
 
 ADD . /django_ec2
-
 WORKDIR /django_ec2
 
 RUN pip install -r requirements.txt
 
-RUN export $(cat .env) && python manage.py makemigrations
+# RUN export $(cat .env) && python manage.py makemigrations
+# RUN export $(cat .env) && python manage.py migrate
 
-RUN export $(cat .env) && python manage.py migrate
-
-CMD export $(cat .env) && python manage.py runserver 0.0.0.0:80
+CMD python manage.py runserver 0.0.0.0:80

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN . deploy/env && python manage.py collectstatic
 # since we're running as a non-root user, we need to run the web server on a non-port (i.e., > 1024).
 # we use port forwarding to map port 8000 in the container to port 80 on the host
 # - an even better move would be to use port 8000 on the host and use port forwarding on the EC2 firewall
-CMD python manage.py runserver 0.0.0.0:8000
+CMD ["/django_ec2/docker/serve.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,14 @@ WORKDIR /django_ec2
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
-# copy the app itself
+# copy the app itself before fixing permissions
 COPY . .
+USER root
+RUN chown -R django:django /django_ec2
+USER django
+
+# build the static resources (without this, the production server will fail)
+RUN . deploy/env && python manage.py collectstatic
 
 # RUN export $(cat .env) && python manage.py makemigrations
 # RUN export $(cat .env) && python manage.py migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ USER django
 # build the static resources (without this, the production server will fail)
 RUN . deploy/env && python manage.py collectstatic
 
-# RUN export $(cat .env) && python manage.py makemigrations
-# RUN export $(cat .env) && python manage.py migrate
-
 # since we're running as a non-root user, we need to run the web server on a non-port (i.e., > 1024).
 # we use port forwarding to map port 8000 in the container to port 80 on the host
 # - an even better move would be to use port 8000 on the host and use port forwarding on the EC2 firewall

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,31 @@
 FROM python:3.6-alpine
-USER django
 RUN apk add --no-cache \
+  bash \
   gcc \
-  musl-dev
-  python3-dev \
+  musl-dev \
+  python3-dev
 
-ADD . /django_ec2
+# we run as a non-root user to mitigate the possibility of using a Docker root shell to obtain root on the host
+# - note that we also create a user with the same uid (1000) as ec2-user to avoid permissions issues when mounting files
+RUN adduser django \
+  --disabled-password \
+  --shell /bin/bash \
+  --uid 1000
+USER django
+ENV PATH "/home/django/.local/bin:${PATH}"
+
+# install the requirements for the app
 WORKDIR /django_ec2
-
+COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+# copy the app itself
+COPY . .
 
 # RUN export $(cat .env) && python manage.py makemigrations
 # RUN export $(cat .env) && python manage.py migrate
 
-CMD python manage.py runserver 0.0.0.0:80
+# since we're running as a non-root user, we need to run the web server on a non-port (i.e., > 1024).
+# we use port forwarding to map port 8000 in the container to port 80 on the host
+# - an even better move would be to use port 8000 on the host and use port forwarding on the EC2 firewall
+CMD python manage.py runserver 0.0.0.0:8000

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 ### Dependency Setup (DEVELOPMENT)
 
-The following will set up a python environment for this project using `virtualenv` . This allows us to keep all your project dependencies (or `pip modules`) in isolation, and running their correct versions. 
+The following will set up a python environment for this project using `virtualenv`.
+This allows us to keep all your project dependencies (or `pip modules`) in isolation, and running their correct versions.
 
 * If you dont have `virtualenv` install: `pip install virtualenv`
 * In the project directory, create the env: `virtualenv djangoEnv` (set djangoEnv to your preferred env name)
@@ -58,7 +59,7 @@ The following will set up a python environment for this project using `virtualen
 
 * Run the suite with `./manage.py test`
 
-### Deployment
+### Deployment (First-Time)
 
 * To SSH into AWS, you can find our private key file in Google Drive and use the AWS login credentials in the handoff doc to get the public DNS
 
@@ -73,3 +74,27 @@ The following will set up a python environment for this project using `virtualen
 * Make starter staff superuser and volunteer account
 
 * Finally run the server on port 80 (still using docker exec, `python manage.py runserver 80`. For exact commands you can scroll the bash history)
+
+
+### Deployment (Ongoing)
+
+The AWS/EC2 deployment of the FLP Inventory app is managed using Docker Compose.
+You will need to ensure that the SQLite database file, `db.sqlite3`, is moved into the `deploy` directory.
+Additionally, you will need to copy the `env` file from Google Drive (containing deployment secrets) to the `deploy` directory (i.e., `deploy/env`).
+To launch the server, you should run:
+
+	$ docker-compose up -d
+
+To check on the state of the server via its logs, you can run:
+
+	$ docker-compose logs
+
+To shutdown the server, you should run:
+
+	$ docker-compose down
+
+To restart an already-running server, you should run:
+
+	$ docker-compose restart
+
+Note that all of the above commands should be run from the root of this directory.

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,3 +1,3 @@
-# you should place your sensitive db.sqlite3 and .env files into here during deployment
+# you should place your sensitive db.sqlite3 and env files into here during deployment
 # this .gitignore file makes sure that you don't accidentally commit those files to your repo
 *

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,3 @@
+# you should place your sensitive db.sqlite3 and .env files into here during deployment
+# this .gitignore file makes sure that you don't accidentally commit those files to your repo
+*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+version: "3.3"
+
+services:
+  django:
+    container_name: django
+    env_file:
+      - ./deploy/env
+    build:
+      context: .
+    restart: unless-stopped
+    ports:
+      - 8000:8000
+    volumes:
+      - ./deploy/db.sqlite3:/django_ec2/db.sqlite3:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,6 @@ services:
       context: .
     restart: unless-stopped
     ports:
-      - 8000:8000
+      - 80:8000
     volumes:
       - ./deploy/db.sqlite3:/django_ec2/db.sqlite3:rw

--- a/docker/serve.sh
+++ b/docker/serve.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# This file is copied into the Docker container and is used to both:
+# - spin up the email backups job in the background
+# - launch the webserver and listen to requests on port 8000
+#
+# since we're running as a non-root user, we need to run the web server on a non-port (i.e., > 1024).
+# we use port forwarding to map port 8000 in the container to port 80 on the host
+# - an even better move would be to use port 8000 on the host and use port forwarding on the EC2 firewall
+pushd /django_ec2
+python email_backups.py &
+python manage.py runserver 0.0.0.0:8000

--- a/email_backups.py
+++ b/email_backups.py
@@ -1,4 +1,5 @@
-import time 
+#!/usr/bin/env python
+import time
 import os
 
 SECONDS_PER_WEEK = 604800


### PR DESCRIPTION
This PR changes a few aspects of the AWS/EC2 deployment. Most notably, it uses `docker-compose` to (a) manage the deployment process, rather than relying on users to manually follow certain steps, and (b) it uses volume mounting to ensure that the database is persisted between container starts and stops. (The previous deployment would lose the database if the EC2 instance ever crashed.)